### PR TITLE
gemspec: Drop deprecated and ignored property

### DIFF
--- a/remotable.gemspec
+++ b/remotable.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Binds an ActiveRecord model to a remote resource and keeps the two synchronized}
   s.description = %q{Remotable keeps a locally-stored ActiveRecord synchronized with a remote resource.}
 
-  s.rubyforge_project = "remotable"
-
   s.add_dependency "activeresource", ">= 3.2"
   s.add_dependency "activerecord"
   s.add_dependency "activesupport"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.

[Source code location with the deprecation](https://github.com/rubygems/rubygems/blob/a7e2f87e94791206d2e7bb12ff7ce75442811ce8/lib/rubygems/specification.rb#L735)