### PR TITLE
Made with_remote_model threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+### 0.5.1
+* **Bugfix** Addressed an issue where `Remotable.with_remote_model` could leave a model with the wrong `remote_model` when used in a multithreaded environment.
+
+***
+
+_TODO: Backfill for previous releases_

--- a/lib/remotable.rb
+++ b/lib/remotable.rb
@@ -5,6 +5,7 @@ require "remotable/validate_models"
 require "remotable/with_remote_model_proxy"
 require "remotable/errors"
 require "remotable/logger_wrapper"
+require "active_resource/threadsafe_attributes"
 
 
 # Remotable keeps a locally-stored ActiveRecord
@@ -36,6 +37,7 @@ require "remotable/logger_wrapper"
 module Remotable
   extend Nosync
   extend ValidateModels
+  include ThreadsafeAttributes
 
   # By default, Remotable will validate the models you
   # supply it via +remote_model+. You can set validate_models
@@ -52,6 +54,8 @@ module Remotable
     attr_accessor :log_level
     Remotable.log_level = :debug
   end
+
+  threadsafe_attribute :_remote_model, :__remotable_included
 
 
 
@@ -88,17 +92,17 @@ module Remotable
   #
   def remote_model(*args)
     if args.length >= 1
-      @remote_model = args.first
+      self._remote_model = args.first
 
-      @__remotable_included ||= begin
+      self.__remotable_included ||= begin
         require "remotable/active_record_extender"
         include Remotable::ActiveRecordExtender
         true
       end
 
-      extend_remote_model(@remote_model) if @remote_model
+      extend_remote_model(_remote_model) if _remote_model
     end
-    @remote_model
+    _remote_model
   end
 
 

--- a/lib/remotable/version.rb
+++ b/lib/remotable/version.rb
@@ -1,3 +1,3 @@
 module Remotable
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
### Summary
Before, we were setting `remote_model` on a class variable ... and then modifying it for the duration of a block in `with_remote_model`; this was _very not_ threadsafe. By moving from using a module-level instance variable to a threadsafe attribute, we unlock thread safety for `with_remote_model`.

FWIW, I wrote the test after-the-fact, but I reverted my changes to `remotable.rb` after writing the test, and the previously-passing test started failing. 🙂 