### PR TITLE
Remove Threadsafe Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.6.0
+* **Bugfix** Completely removed dependence on `activeresource`'s `ThreadsafeAttributes`. This makes multithreaded behavior more deterministic and involves fewer edgecases, since things meant to be global state are reverted back to being so, while things meant to have a per-thread scope are constrained as they should be.
+
 ### 0.5.1
 * **Bugfix** Addressed an issue where `Remotable.with_remote_model` could leave a model with the wrong `remote_model` when used in a multithreaded environment.
 

--- a/lib/remotable/active_record_extender.rb
+++ b/lib/remotable/active_record_extender.rb
@@ -1,7 +1,6 @@
 require "remotable/core_ext"
 require "active_support/concern"
 require "active_support/core_ext/array/wrap"
-require "active_resource/threadsafe_attributes"
 require "benchmark"
 
 
@@ -43,10 +42,9 @@ module Remotable
 
     module ClassMethods
       include Nosync
-      include ThreadsafeAttributes
 
-      threadsafe_attribute :_remote_key, :_expires_after, :_remote_attribute_map,
-        :_local_attribute_routes, :_remote_timeout, :remotable_skip_validation_on_sync
+      attr_accessor :_remote_attribute_map, :_local_attribute_routes, :_expires_after,
+        :_remote_timeout, :remotable_skip_validation_on_sync
 
       def nosync?
         return true if remote_model.nil?
@@ -83,9 +81,9 @@ module Remotable
           # Set up a finder method for the remote_key
           fetch_with(local_key(remote_key), options)
 
-          self._remote_key = remote_key
+          @remote_key = remote_key
         else
-          _remote_key || generate_default_remote_key
+          @remote_key || generate_default_remote_key
         end
       end
 
@@ -431,7 +429,7 @@ module Remotable
 
 
       def generate_default_remote_key
-        return _remote_key if _remote_key
+        return @remote_key if @remote_key
         raise("No remote key supplied and :id is not a remote attribute") unless remote_attribute_names.member?(:id)
         remote_key(:id)
       end

--- a/lib/remotable/nosync.rb
+++ b/lib/remotable/nosync.rb
@@ -1,5 +1,3 @@
-require "active_resource/threadsafe_attributes"
-
 module Remotable
   module Nosync
 
@@ -50,7 +48,6 @@ module Remotable
     end
 
     module ClassMethods
-      include ThreadsafeAttributes
       include InstanceMethods
 
       def reset_nosync!
@@ -62,7 +59,15 @@ module Remotable
       end
 
     private
-      threadsafe_attribute :_nosync
+
+      def _nosync
+        Thread.current.thread_variable_get "remotable.nosync.#{self.object_id}"
+      end
+
+      def _nosync=(value)
+        Thread.current.thread_variable_set "remotable.nosync.#{self.object_id}", value
+      end
+
     end
 
   end

--- a/lib/remotable/version.rb
+++ b/lib/remotable/version.rb
@@ -1,3 +1,3 @@
 module Remotable
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
### Summary
~~Seems I might have been a little too aggressive with the `threadsafe_attribute` s.~~ 😅  ~~I believe in some cases, it could be the case that `Remotable::ActiveRecordExtender` could be included multiple times in a multithreaded environment; I'm not sure that's necessarily _bad_, but on the other hand we were previously actively checking so as not to do that.~~ 😓

ThreadsafeAttributes was a good idea. However, its implementation was not a good fit for how we need state to work in Remotable: When a threadsafe attribute is first set, it sets the value of the variable on the current thread and then _also_ on the main thread, if the variable is not yet defined on the main thread. There were two different situations where this was a bad idea for remotable:

First, when doing class initialization, defaults are set for several attributes in the `ActiveRecordExtender`, with the intent that the consuming class would be able to set their own values later. However, if the class initialization is not run on the main thread, setting the defaults in `ActiveRecordExtender` would set the default value on both the current and the main threads, but the override that followed would only be set on the current thread. This led to only one thread having the correct, intended value for that attribute for the model.

The second situation was when setting a value temporarily for the span of a block, and then setting the value back afterwards. Again, assuming the wrapping method was called on a non-main thread, it would set that override value for the current thread _and_ the main thread, if the main thread was not yet defined, but then the call to set it back to its original value after the block had executed would _only_ reset the value on the non-main thread, since we just ensured the value was defined on the main thread before running the block.

The solution, then, was twofold. For the first situation, since the intent is to set values tied to the actual model, which are meant to be global, we simply reverted to using class variables, which are set across threads. For the second situation, we manually wrapped thread variables that only applied to the current thread and didn't set anything on the main thread. By limiting scope in this way, we prevented polluting the main thread with values intended to be temporary.