### PR TITLE
Inherited nosync?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.6.1
+* **Bugfix** Tweaked the behavior of `Remotable.nosync?` to defer to a value set on the main thread if no value has been set for the current thread.
+
 ### 0.6.0
 * **Bugfix** Completely removed dependence on `activeresource`'s `ThreadsafeAttributes`. This makes multithreaded behavior more deterministic and involves fewer edgecases, since things meant to be global state are reverted back to being so, while things meant to have a per-thread scope are constrained as they should be.
 

--- a/lib/remotable/nosync.rb
+++ b/lib/remotable/nosync.rb
@@ -61,11 +61,17 @@ module Remotable
     private
 
       def _nosync
-        Thread.current.thread_variable_get "remotable.nosync.#{self.object_id}"
+        return Thread.current.thread_variable_get "remotable.nosync.#{self.object_id}" if nosync_defined_on?(Thread.current)
+        return Thread.main.thread_variable_get "remotable.nosync.#{self.object_id}" if nosync_defined_on?(Thread.main)
       end
 
       def _nosync=(value)
         Thread.current.thread_variable_set "remotable.nosync.#{self.object_id}", value
+        Thread.current.thread_variable_set "remotable.nosync.#{self.object_id}.defined", true
+      end
+
+      def nosync_defined_on?(thread)
+        !!thread.thread_variable_get("remotable.nosync.#{self.object_id}.defined")
       end
 
     end

--- a/lib/remotable/version.rb
+++ b/lib/remotable/version.rb
@@ -1,3 +1,3 @@
 module Remotable
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/test/nosync_test.rb
+++ b/test/nosync_test.rb
@@ -48,6 +48,18 @@ class NoSyncTest < ActiveSupport::TestCase
     assert_equal true, Tenant.nosync?
   end
 
+  test "nosync? should defer to the main thread's value if set there but not on the current thread" do
+    Remotable.nosync!
+    subthread = Thread.new do
+      assert Remotable.nosync?
+      Remotable.reset_nosync!
+      refute Remotable.nosync?
+      Thread.stop
+    end
+    sleep 0.1 while subthread.status != "sleep"
+    assert Remotable.nosync?
+  end
+
 
 
   # ========================================================================= #


### PR DESCRIPTION
### Summary
Defers to the `_nosync` value defined on the main thread if it's not been defined on the current thread already. This allows spawned threads to inherit an explicitly set `nosync?` value until such time as they're set one way or another on the current thread.