### PR TITLE
Removed deprecated calls to `URI.encode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 0.6.2
-* **Fix** Replace obsolete call to URI.escape with CGI.escape
+* **Fix** Replaced deprecated calls to URI.escape
 
 ### 0.6.1
 * **Bugfix** Tweaked the behavior of `Remotable.nosync?` to defer to a value set on the main thread if no value has been set for the current thread.

--- a/lib/remotable/active_record_extender.rb
+++ b/lib/remotable/active_record_extender.rb
@@ -348,7 +348,7 @@ module Remotable
       end
 
       def remote_path_for_simple_key(route, local_key, value)
-        route.gsub(/:#{local_key}/, CGI.escape(value.to_s))
+        route.gsub(/:#{local_key}/, ERB::Util.url_encode(value.to_s))
       end
 
       def remote_path_for_composite_key(route, local_key, values)
@@ -358,7 +358,7 @@ module Remotable
         end
 
         (0...values.length).inject(route) do |route, i|
-          route.gsub(/:#{local_key[i]}/, URI.escape(values[i].to_s))
+          route.gsub(/:#{local_key[i]}/, ERB::Util.url_encode(values[i].to_s))
         end
       end
 

--- a/test/active_resource_test.rb
+++ b/test/active_resource_test.rb
@@ -141,8 +141,8 @@ class ActiveResourceTest < ActiveSupport::TestCase
     simple_key_path = Tenant.remote_path_for_simple_key("tenants/:slug", :slug, bad_uri)
     composite_key_path = Tenant.remote_path_for_composite_key(route, [:group_id, :slug], [5, bad_uri])
 
-    assert_equal "tenants/http://()%20%7B%20:;%20%7D;%20ping%20-c%2023%200.0.0.0", simple_key_path
-    assert_equal "groups/5/tenants/http://()%20%7B%20:;%20%7D;%20ping%20-c%2023%200.0.0.0", composite_key_path
+    assert_equal "tenants/http%3A%2F%2F%28%29%20%7B%20%3A%3B%20%7D%3B%20ping%20-c%2023%200.0.0.0", simple_key_path
+    assert_equal "groups/5/tenants/http%3A%2F%2F%28%29%20%7B%20%3A%3B%20%7D%3B%20ping%20-c%2023%200.0.0.0", composite_key_path
   end
 
 


### PR DESCRIPTION
### Summary
I noticed only after I'd merged the previous PR that there was a failing test and one more unaddressed call to `URI.encode` 😓 

`URI.encode` and `CGI.encode` are not entirely interchangeable. It would seem that the former doesn't escape slashes, etc. while the latter is more aggressive in escaping everything, but replaces spaces with `+` instead of `%20`. I opted to go a different route with `ERB::Util.url_encode`, which aggressively escapes everything BUT also uses `%20` when escaping spaces, which is most consistent with current behavior in remotable. I don't love having to have updated the test output in this case, but it _should_ still work with any real server, even if the actual URL produced is different.