### PR TITLE
Unsafe nosync!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.6.4
+* **Feature** Added `Remotable.unsafe_nosync!` method to set `nosync` globally using a class variable. As the method name indicates, this is not threadsafe and should only be used for testing or other situations where thread safety is not an issue.
+* **Bugfix** Stopped deferring to `Thread.main` if `nosync` was unset on the current thread; while convenient for tests (see above), it ended up allowing requests to leak state if they were handled on the main thread.
+
+
 ### 0.6.3
 * **Fix** Replaced deprecated calls to URI.escape
 

--- a/lib/remotable/nosync.rb
+++ b/lib/remotable/nosync.rb
@@ -50,8 +50,14 @@ module Remotable
     module ClassMethods
       include InstanceMethods
 
+      def unsafe_nosync!
+        nosync!
+        @_unsafe_nosync = true
+      end
+
       def reset_nosync!
         self.nosync = nil
+        remove_instance_variable :@_unsafe_nosync if instance_variable_defined? :@_unsafe_nosync
       end
 
       def nosync=(val)
@@ -62,7 +68,7 @@ module Remotable
 
       def _nosync
         return Thread.current.thread_variable_get "remotable.nosync.#{self.object_id}" if nosync_defined_on?(Thread.current)
-        return Thread.main.thread_variable_get "remotable.nosync.#{self.object_id}" if nosync_defined_on?(Thread.main)
+        @_unsafe_nosync if instance_variable_defined?(:@_unsafe_nosync)
       end
 
       def _nosync=(value)

--- a/lib/remotable/version.rb
+++ b/lib/remotable/version.rb
@@ -1,3 +1,3 @@
 module Remotable
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end


### PR DESCRIPTION
### Summary
Threads are hard! 😆 Two opposing requirements led to this tweak:
1️⃣ If the main thread handles requests along with child threads, then having `nosync?` defer to the main thread if unset on the current thread could lead to temporary state set on the main thread leaking out into the child thread. As such, `nosync?` is now entirely thread-local.
2️⃣ In some client tests, a server is spawned to simulate a server taking requests. In this situation, threads are used, meaning that any `Remotable.nosync!` set in the main test is ignored by the mock server. To address this particular, testing-related situation, `unsafe_nosync!` has been introduced, which sets a class variable instead of a thread-local variable. As the name indicates, this is _very_ not threadsafe.