### PR TITLE
Use the class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.7.0
+* **Bugfix** Ensured ActiveRecord models were using Nosync's `ClassMethods` instead of the non-threadsafe `InstanceMethods`
+
 ### 0.6.4
 * **Feature** Added `Remotable.unsafe_nosync!` method to set `nosync` globally using a class variable. As the method name indicates, this is not threadsafe and should only be used for testing or other situations where thread safety is not an issue.
 * **Bugfix** Stopped deferring to `Thread.main` if `nosync` was unset on the current thread; while convenient for tests (see above), it ended up allowing requests to leak state if they were handled on the main thread.

--- a/lib/remotable/active_record_extender.rb
+++ b/lib/remotable/active_record_extender.rb
@@ -17,6 +17,16 @@ module Remotable
 
 
     included do
+      extend Nosync
+
+      # Has to be re-defined _after_ Nosync is extended, which cannot
+      # be done as part of the ClassMethods module
+      def self.nosync?
+        return true if remote_model.nil?
+        return super if nosync_value?
+        Remotable.nosync?
+      end
+
       before_update   :update_remote_resource,  :unless => :nosync?
       before_create   :create_remote_resource,  :unless => :nosync?
       before_destroy  :destroy_remote_resource, :unless => :nosync?
@@ -41,16 +51,10 @@ module Remotable
 
 
     module ClassMethods
-      include Nosync
 
       attr_accessor :_remote_attribute_map, :_local_attribute_routes, :_expires_after,
         :_remote_timeout, :remotable_skip_validation_on_sync
 
-      def nosync?
-        return true if remote_model.nil?
-        return super if nosync_value?
-        Remotable.nosync?
-      end
 
       # Sets the key with which a resource is identified remotely.
       # If no remote key is set, the remote key is assumed to be :id.

--- a/lib/remotable/version.rb
+++ b/lib/remotable/version.rb
@@ -1,3 +1,3 @@
 module Remotable
-  VERSION = "0.6.4"
+  VERSION = "0.7.0"
 end

--- a/test/remotable_test.rb
+++ b/test/remotable_test.rb
@@ -170,4 +170,17 @@ class RemotableTest < ActiveSupport::TestCase
   end
 
 
+
+  # ========================================================================= #
+  # ActiveRecordExtender                                                      #
+  # ========================================================================= #
+
+  test "should extend an ActiveRecord subclass with Nosync class methods" do
+    class Example5 < ActiveRecord::Base; self.table_name = "tenants"; end
+    Example5.remote_model BespokeModel.new
+    # Method is _only_ on the class version
+    assert Example5.respond_to?(:unsafe_nosync!)
+  end
+
+
 end


### PR DESCRIPTION
### Summary
Up until this point, ActiveRecord models _**were using Nosync's `InstanceMethods` instead of its `ClassMethods`!!!**_ This was especially troublesome, as the `InstanceMethods` would not be threadsafe in a class context (hence the `ClassMethods`), meaning that all the work on thread safety up to this point was applying _only_ to the `Remotable` module itself. 🤦 This change makes it so that calling `nosync` methods on an ActiveRecord model class will also be threadsafe.